### PR TITLE
Handled the case that the websocket connection is gone.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -98,8 +98,10 @@ wss.on('connection', function connection(ws) {
     }
     var delay = Math.floor(Math.random()*5000) + 500;
     timeout = setTimeout(function () {
-      sendRandomWorld();
-      resetTimeout();
+      if (ws.OPEN == ws.readyState) {
+        sendRandomWorld();
+        resetTimeout();
+      }
     }, delay);
   }
 


### PR DESCRIPTION
Right now the websocket ends up throwing an exception when it is being written to
which takes down the whole server. This simply stops sending messages to the
disconnected websocket.
